### PR TITLE
Use default Larastan rules

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,16 +12,3 @@ parameters:
     ignoreErrors:
 
     excludePaths:
-
-    polluteScopeWithLoopInitialAssignments: false
-    polluteScopeWithAlwaysIterableForeach: false
-    checkAlwaysTrueCheckTypeFunctionCall: true
-    checkAlwaysTrueInstanceof: true
-    checkAlwaysTrueStrictComparison: true
-    checkExplicitMixedMissingReturn: true
-    checkFunctionNameCase: true
-    checkInternalClassCaseSensitivity: true
-    reportMaybesInMethodSignatures: true
-    reportStaticMethodSignatures: true
-    checkTooWideReturnTypesInProtectedAndPublicMethods: true
-    checkMissingIterableValueType: false


### PR DESCRIPTION
This PR just removes a few rules that were defined in the Larastan config file. I've updated it so that we are only using the default rules