### PR TITLE
Add buttons which sort the issues on the page accordingly

### DIFF
--- a/app/Http/Controllers/IssueController.php
+++ b/app/Http/Controllers/IssueController.php
@@ -7,10 +7,24 @@ use Illuminate\Contracts\View\View;
 
 class IssueController extends Controller
 {
+    private const ACCEPTABLE_SORT_FIELDS = ['title', 'repoName', 'createdAt'];
+    private $sort;
+
+    public function __construct()
+    {
+        $this->sort = null;
+
+        if(request()->query('sort')) {
+            if (in_array(request()->query('sort'), self::ACCEPTABLE_SORT_FIELDS)) {
+                $this->sort = request()->query('sort');
+            }
+        }
+    }
+
     public function __invoke(IssueService $issueService): View
     {
         return view('issues.index', [
-            'issues' => $issueService->getAll(),
+            'issues' => $issueService->getAll($this->sort),
         ]);
     }
 }

--- a/app/Services/IssueService.php
+++ b/app/Services/IssueService.php
@@ -19,12 +19,22 @@ class IssueService
      *
      * @return array<Issue>
      */
-    public function getAll(): array
+    public function getAll(String $sort = null): array
     {
-        return collect(config('repos.repos'))
-            ->flatMap(fn (array $repo): array => $this->getIssuesForRepo($repo))
-            ->shuffle()
-            ->all();
+        if ($sort) {
+            $allRepos = collect(config('repos.repos'))
+                ->flatMap(fn (array $repo): array => $this->getIssuesForRepo($repo))
+                ->sortBy($sort)
+                ->all();
+        }
+        else {
+            $allRepos = collect(config('repos.repos'))
+                ->flatMap(fn (array $repo): array => $this->getIssuesForRepo($repo))
+                ->shuffle()
+                ->all();
+        }
+        
+        return $allRepos;
     }
 
     /**

--- a/resources/views/issues/index.blade.php
+++ b/resources/views/issues/index.blade.php
@@ -47,6 +47,18 @@
         </div>
 
         <div class="mt-12">
+            <p>
+                Sort By: 
+                <a href="?sort=createdAt" class="bg-blue-100 hover:bg-blue-200 text-blue-800 text-sm font-medium mr-2 px-5 py-1 rounded dark:bg-blue-200 dark:text-blue-800 dark:hover:bg-blue-300">
+                    Created Date
+                </a>
+                <a href="?sort=repoName" class="bg-blue-100 hover:bg-blue-200 text-blue-800 text-sm font-medium mr-2 px-5 py-1 rounded dark:bg-blue-200 dark:text-blue-800 dark:hover:bg-blue-300">
+                    Repo Name
+                </a>
+                <a href="?sort=title" class="bg-blue-100 hover:bg-blue-200 text-blue-800 text-sm font-medium mr-2 px-5 py-1 rounded dark:bg-blue-200 dark:text-blue-800 dark:hover:bg-blue-300">
+                    Title
+                </a>
+            </p>
             <p class="text-right">
                 Found <span class="font-bold">{{ count($issues) }}</span> issue(s)
             </p>


### PR DESCRIPTION
I've changed the IssueController to check for a 'sort' query parameter. If it's in a list of allowed sort fields then it's passed to the IssueService to use when building the collection.

On the UI I've added 3 buttons to the top of the page which are simply links to the correct page e.g. /?sort=createdAt.

Any feedback greatly apprciated.