### PR TITLE
Add an option to show the sidebar on mobile devices

### DIFF
--- a/resources/views/components/side-bar.blade.php
+++ b/resources/views/components/side-bar.blade.php
@@ -6,7 +6,7 @@
     'ignoredUrls'
 ])
 
-<div class="w-1/4 my-10 pr-6 hidden md:block">
+<div {{ $attributes->class('md:w-1/4 my-10 pr-6') }} x-transition>
     <label for="search" class="inline-block pb-1">Search:</label>
     <input id="search"
            wire:model.debounce="searchTerm"
@@ -34,31 +34,33 @@
         <hr class="my-6 border-gray-300 w-3/4 mx-auto dark:border-slate-500">
     @endif
 
-    <div class="flex justify-between pb-1 items-center">
-        <p>Repositories:</p>
-        <p class="text-gray-400 text-sm">({{ $repos->count() }})</p>
-    </div>
-
-    @foreach($repos as $repo)
-        <div>
-            <a href="https://github.com/{{ $repo['owner'] }}/{{ $repo['name'] }}" class="inline-block items-center px-3 py-1 my-0.5 rounded text-xs font-bold bg-green-400 dark:bg-green-600 text-white hover:bg-green-500 dark:hover:bg-green-700 transition ease-out">
-                {{ $repo['owner'] }}/{{ $repo['name'] }}
-            </a>
+    <div class="hidden md:block">
+        <div class="flex justify-between pb-1 items-center hidden">
+            <p>Repositories:</p>
+            <p class="text-gray-400 text-sm">({{ $repos->count() }})</p>
         </div>
-    @endforeach
 
-    <hr class="my-6 border-gray-300 w-3/4 mx-auto dark:border-slate-500">
+        @foreach($repos as $repo)
+            <div>
+                <a href="https://github.com/{{ $repo['owner'] }}/{{ $repo['name'] }}" class="inline-block items-center px-3 py-1 my-0.5 rounded text-xs font-bold bg-green-400 dark:bg-green-600 text-white hover:bg-green-500 dark:hover:bg-green-700 transition ease-out">
+                    {{ $repo['owner'] }}/{{ $repo['name'] }}
+                </a>
+            </div>
+        @endforeach
 
-    <div class="flex justify-between pb-1 items-center">
-        <p>Labels:</p>
-        <p class="text-gray-400 text-sm">({{ count($labels) }})</p>
-    </div>
+        <hr class="my-6 border-gray-300 w-3/4 mx-auto dark:border-slate-500">
 
-    @foreach($labels as $label)
-        <div>
-            <p class="inline-block items-center px-3 py-1 my-0.5 rounded text-xs font-bold border bg-gray-400 dark:bg-gray-600 text-white">
-                {{ $label }}
-            </p>
+        <div class="flex justify-between pb-1 items-center">
+            <p>Labels:</p>
+            <p class="text-gray-400 text-sm">({{ count($labels) }})</p>
         </div>
-    @endforeach
+
+        @foreach($labels as $label)
+            <div>
+                <p class="inline-block items-center px-3 py-1 my-0.5 rounded text-xs font-bold border bg-gray-400 dark:bg-gray-600 text-white">
+                    {{ $label }}
+                </p>
+            </div>
+        @endforeach
+    </div>
 </div>

--- a/resources/views/issues/index.blade.php
+++ b/resources/views/issues/index.blade.php
@@ -22,7 +22,7 @@
         x-init="shouldUseDarkMode() ? toggleDarkMode(true) : toggleDarkMode(false)"
 >
 <div class="max-w-6xl mx-auto py-3" x-cloak>
-    <div class="w-full p-4 sm:p-0 mx-auto mt-0 sm:mt-12">
+    <div class="w-full p-4 xs:p-0 mx-auto mt-0 sm:mt-12">
         <x-header/>
 
         @livewire('list-issues')

--- a/resources/views/livewire/list-issues.blade.php
+++ b/resources/views/livewire/list-issues.blade.php
@@ -14,7 +14,12 @@
 
     <main class="w-full md:w-3/4">
         <div class="flex justify-between md:justify-end items-center flex-wrap">
-            <p class="underline hover:text-gray-900 hover:cursor-pointer md:hidden" x-on:click="showSideBar = ! showSideBar" x-text="showSideBar ? 'Hide filter' : 'Show filter'"></p>
+            <button type="button"
+                    x-on:click="showSideBar = ! showSideBar"
+                    x-text="showSideBar ? 'Hide filter' : 'Show filter'"
+                    class="flex justify-center items-center px-4 py-1.5 border border-transparent font-medium rounded-md shadow-sm text-white bg-gray-800 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 dark:hover:bg-gray-900 transition ease-out"
+            >
+            </button>
             <p>
                 Found <span class="font-bold">{{ count($issues) }}</span> {{ str('issue')->plural(count($issues)) }}
             </p>

--- a/resources/views/livewire/list-issues.blade.php
+++ b/resources/views/livewire/list-issues.blade.php
@@ -21,7 +21,7 @@
             >
             </button>
             <p>
-                Found <span class="font-bold">{{ count($issues) }}</span> {{ str('issue')->plural(count($issues)) }}
+                Found <span class="font-bold">{{ count($issues) }}</span> {{ $showIgnoredIssues ? 'ignored' : '' }} {{ str('issue')->plural(count($issues)) }}
             </p>
         </div>
 

--- a/resources/views/livewire/list-issues.blade.php
+++ b/resources/views/livewire/list-issues.blade.php
@@ -1,17 +1,21 @@
 <div
     x-data="{
+        'showSideBar': false,
         'ignoredUrls': @entangle('ignoredUrls'),
         getIgnoredUrls(){
             this.ignoredUrls = Array.from(JSON.parse(localStorage.getItem('ignoreUrl')) || []);
         }
     }"
     x-init="getIgnoredUrls();"
-    class="mt-12 flex">
-    <x-side-bar :repos="$repos" :labels="$labels" :sorts="$sorts" :ignored-urls="$ignoredUrls"/>
+    class="mt-12 md:flex">
+
+    <x-side-bar :repos="$repos" :labels="$labels" :sorts="$sorts" :ignored-urls="$ignoredUrls" x-show="showSideBar" x-cloak/>
+    <x-side-bar :repos="$repos" :labels="$labels" :sorts="$sorts" :ignored-urls="$ignoredUrls" class="hidden md:block"/>
 
     <main class="w-full md:w-3/4">
-        <div class="flex justify-end items-center flex-wrap space-y-2 md:space-y-0">
-            <p class="text-right">
+        <div class="flex justify-between md:justify-end items-center flex-wrap">
+            <p class="underline hover:text-gray-900 hover:cursor-pointer md:hidden" x-on:click="showSideBar = ! showSideBar" x-text="showSideBar ? 'Hide filter' : 'Show filter'"></p>
+            <p>
                 Found <span class="font-bold">{{ count($issues) }}</span> {{ str('issue')->plural(count($issues)) }}
             </p>
         </div>

--- a/resources/views/livewire/list-issues.blade.php
+++ b/resources/views/livewire/list-issues.blade.php
@@ -9,7 +9,7 @@
     x-init="getIgnoredUrls();"
     class="mt-12 md:flex">
 
-    <x-side-bar :repos="$repos" :labels="$labels" :sorts="$sorts" :ignored-urls="$ignoredUrls" x-show="showSideBar" x-cloak/>
+    <x-side-bar :repos="$repos" :labels="$labels" :sorts="$sorts" :ignored-urls="$ignoredUrls" x-show="showSideBar" class="block md:hidden" x-cloak/>
     <x-side-bar :repos="$repos" :labels="$labels" :sorts="$sorts" :ignored-urls="$ignoredUrls" class="hidden md:block"/>
 
     <main class="w-full md:w-3/4">
@@ -17,7 +17,7 @@
             <button type="button"
                     x-on:click="showSideBar = ! showSideBar"
                     x-text="showSideBar ? 'Hide filter' : 'Show filter'"
-                    class="flex justify-center items-center px-4 py-1.5 border border-transparent font-medium rounded-md shadow-sm text-white bg-gray-800 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 dark:hover:bg-gray-900 transition ease-out"
+                    class="flex md:hidden justify-center items-center px-4 py-1.5 border border-transparent font-medium rounded-md shadow-sm text-white bg-gray-800 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 dark:hover:bg-gray-900 transition ease-out"
             >
             </button>
             <p>


### PR DESCRIPTION
With #77 merged we can now ignore issues without getting a warning. On mobile there is currently no way of viewing the ignored issues. This PR adds an option to show the sidebar so ignored issues can be shown and un-ignored.

![image](https://user-images.githubusercontent.com/20305359/174313819-827009f6-f9f8-42b3-bc94-4d15f1393908.png)
