### PR TITLE
Decrease github avatar size

### DIFF
--- a/app/Services/IssueService.php
+++ b/app/Services/IssueService.php
@@ -86,7 +86,7 @@ class IssueService
     private function getIssueOwner(array $fetchedIssue): IssueOwner
     {
         // Set avatar size to 48px
-        $fetchedIssue['user']['avatar_url'] .= (parse_url($fetchedIssue['user']['avatar_url'], PHP_URL_QUERY) ? '&' : '?') . 's=48';
+        $fetchedIssue['user']['avatar_url'] .= (parse_url($fetchedIssue['user']['avatar_url'], PHP_URL_QUERY) ? '&' : '?').'s=48';
 
         return new IssueOwner(
             name: $fetchedIssue['user']['login'],

--- a/app/Services/IssueService.php
+++ b/app/Services/IssueService.php
@@ -85,6 +85,9 @@ class IssueService
 
     private function getIssueOwner(array $fetchedIssue): IssueOwner
     {
+        // Set avatar size to 48px
+        $fetchedIssue['user']['avatar_url'] .= (parse_url($fetchedIssue['user']['avatar_url'], PHP_URL_QUERY) ? '&' : '?') . 's=48';
+
         return new IssueOwner(
             name: $fetchedIssue['user']['login'],
             url: $fetchedIssue['user']['html_url'],


### PR DESCRIPTION
By default, GitHub avatars are more than 400*400px, which is far too large for our usecase. The size can be decrease using a `s=[size]` query parameter, for example:

Full: https://avatars.githubusercontent.com/u/39652331?v=4

Smaller: https://avatars.githubusercontent.com/u/39652331?v=4&s=48

This should slighlty improve loading speeds.