### PR TITLE
Strip html input

### DIFF
--- a/resources/views/components/issue-card.blade.php
+++ b/resources/views/components/issue-card.blade.php
@@ -32,7 +32,7 @@
 
     <div class="my-4 overflow-hidden relative" :class="showMore ? '' : 'max-h-32'">
         <article class="prose dark:prose-invert">
-            {!! str($issue->body)->markdown() !!}
+            {!! str($issue->body)->markdown(['html_input' => 'strip']) !!}
         </article>
         <div x-on:click="showMore = ! showMore" :class="showMore ? '' : 'bg-gradient-to-t from-white dark:from-slate-800 to-transparent absolute left-0 bottom-0'" class="font-bold h-20 w-full z-10 text-center pt-14 hover:text-gray-500 cursor-pointer">
             <span x-text="showMore ? 'View less' : 'View more'" class="border-b border-b-green-400">View more</span>


### PR DESCRIPTION
Fixes the current display issue on findapr.io: 
![image](https://user-images.githubusercontent.com/20305359/175548850-a064e8d8-845c-4770-ae17-5a404549384d.png)
