### PR TITLE
Use Bunny Fonts instead of Google Fonts

### DIFF
--- a/resources/views/components/head.blade.php
+++ b/resources/views/components/head.blade.php
@@ -18,7 +18,7 @@
     <meta name="twitter:creator" content="@AshAllenDesign"/>
 
     <!-- Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.bunny.net/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
 
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 


### PR DESCRIPTION
This PR follows suit with https://github.com/laravel/laravel/pull/5952 to deliver the fonts from Bunny Fonts rather than Google Fonts for GDPR purposes.