### PR TITLE
Validate the services config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
+        "ashallendesign/laravel-config-validator": "^2.2",
         "bugsnag/bugsnag-laravel": "^2.0",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^9.19",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,83 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b755dc0f7078488a49e6d8609303c1c9",
+    "content-hash": "d2e1c3886f4acd88b87ea57173b62158",
     "packages": [
+        {
+            "name": "ashallendesign/laravel-config-validator",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ash-jc-allen/laravel-config-validator.git",
+                "reference": "62d18ff316bd71b560c739ac02b4fefbed48ee36"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ash-jc-allen/laravel-config-validator/zipball/62d18ff316bd71b560c739ac02b4fefbed48ee36",
+                "reference": "62d18ff316bd71b560c739ac02b4fefbed48ee36",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^8.0|^9.0",
+                "illuminate/container": "^8.0|^9.0",
+                "illuminate/validation": "^8.0|^9.0",
+                "illuminate/view": "^8.0|^9.0",
+                "nunomaduro/termwind": "^1.6",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "nunomaduro/larastan": "^1.0.0",
+                "orchestra/testbench": "^6.0|^7.0",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "AshAllenDesign\\ConfigValidator\\Providers\\ConfigValidatorProvider"
+                    ],
+                    "aliases": {
+                        "ConfigValidator": "AshAllenDesign\\ConfigValidator\\Facades\\ConfigValidator"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "AshAllenDesign\\ConfigValidator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ash Allen",
+                    "email": "mail@ashallendesign.co.uk"
+                }
+            ],
+            "description": "A package for validating your Laravel app's config.",
+            "homepage": "https://github.com/ash-jc-allen/laravel-config-validator",
+            "keywords": [
+                "ashallendesign",
+                "config",
+                "laravel",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/ash-jc-allen/laravel-config-validator/issues",
+                "source": "https://github.com/ash-jc-allen/laravel-config-validator/tree/v2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ash-jc-allen",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-05-25T09:07:03+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.9.3",
@@ -2333,6 +2408,92 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v4.14.0"
             },
             "time": "2022-05-31T20:59:12+00:00"
+        },
+        {
+            "name": "nunomaduro/termwind",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/termwind.git",
+                "reference": "10065367baccf13b6e30f5e9246fa4f63a79eb1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/10065367baccf13b6e30f5e9246fa4f63a79eb1d",
+                "reference": "10065367baccf13b6e30f5e9246fa4f63a79eb1d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^8.0",
+                "symfony/console": "^5.3.0|^6.0.0"
+            },
+            "require-dev": {
+                "ergebnis/phpstan-rules": "^1.0.",
+                "illuminate/console": "^8.0|^9.0",
+                "illuminate/support": "^8.0|^9.0",
+                "laravel/pint": "^1.0.0",
+                "pestphp/pest": "^1.21.0",
+                "pestphp/pest-plugin-mock": "^1.0",
+                "phpstan/phpstan": "^1.4.6",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "symfony/var-dumper": "^5.2.7|^6.0.0",
+                "thecodingmachine/phpstan-strict-rules": "^1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Termwind\\Laravel\\TermwindServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php"
+                ],
+                "psr-4": {
+                    "Termwind\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Its like Tailwind CSS, but for the console.",
+            "keywords": [
+                "cli",
+                "console",
+                "css",
+                "package",
+                "php",
+                "style"
+            ],
+            "support": {
+                "issues": "https://github.com/nunomaduro/termwind/issues",
+                "source": "https://github.com/nunomaduro/termwind/tree/v1.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/xiCO2k",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-08-01T11:03:24+00:00"
         },
         {
             "name": "phpoption/phpoption",

--- a/config-validation/bugsnag.php
+++ b/config-validation/bugsnag.php
@@ -1,0 +1,7 @@
+<?php
+
+use AshAllenDesign\ConfigValidator\Services\Rule;
+
+return [
+    Rule::make('api_key')->rules(['string', 'required'])->environments(['production']),
+];

--- a/config-validation/services.php
+++ b/config-validation/services.php
@@ -3,21 +3,9 @@
 use AshAllenDesign\ConfigValidator\Services\Rule;
 
 return [
-    /*
-    |--------------------------------------------------------------------------
-    | Local
-    |--------------------------------------------------------------------------
-    */
-    Rule::make('github.username')->rules(['string', 'nullable'])->environments(['local']),
-
-    Rule::make('github.token')->rules(['string', 'nullable'])->environments(['local']),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Production
-    |--------------------------------------------------------------------------
-    */
     Rule::make('github.username')->rules(['string', 'required'])->environments(['production']),
 
     Rule::make('github.token')->rules(['string', 'required'])->environments(['production']),
+
+    Rule::make('ohdear.ping_url')->rules(['url', 'required'])->environments(['production']),
 ];

--- a/config-validation/services.php
+++ b/config-validation/services.php
@@ -1,0 +1,23 @@
+<?php
+
+use AshAllenDesign\ConfigValidator\Services\Rule;
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Local
+    |--------------------------------------------------------------------------
+    */
+    Rule::make('github.username')->rules(['string', 'nullable'])->environments(['local']),
+
+    Rule::make('github.token')->rules(['string', 'nullable'])->environments(['local']),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Production
+    |--------------------------------------------------------------------------
+    */
+    Rule::make('github.username')->rules(['string', 'required'])->environments(['production']),
+
+    Rule::make('github.token')->rules(['string', 'required'])->environments(['production']),
+];


### PR DESCRIPTION
This PR uses `ashallendesign/laravel-config-validator` to validate some of the config fields that we're using for GitHub, Oh Dear and Bugsnag.

I've also added the command to the deploy script for the site (on Forge) so that I can be sure we have the right fields set up for new features.