### PR TITLE
Added batching for preloading repos

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,9 +16,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('repos:preload')
-            ->hourly()
-            ->then(fn () => $this->call('issues:tweet'));
+        $schedule->command('repos:preload')->hourly();
 
         // Ping OhDear to make sure the scheduler and default queue is running.
         $schedule->job(new SendPing(config('services.ohdear.ping_url')))->everyMinute();

--- a/app/Jobs/PreloadIssuesForRepos.php
+++ b/app/Jobs/PreloadIssuesForRepos.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Jobs;
+
+use App\DataTransferObjects\Repository;
+use App\Services\IssueService;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class PreloadIssuesForRepos implements ShouldQueue
+{
+    use Batchable;
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * @param Collection<Repository> $repos
+     */
+    public function __construct(private readonly Collection $repos)
+    {
+        //
+    }
+
+    public function handle(IssueService $issueService): void
+    {
+        foreach ($this->repos as $repo) {
+            $issueService->getIssuesForRepo($repo);
+        }
+    }
+}

--- a/app/Services/IssueService.php
+++ b/app/Services/IssueService.php
@@ -32,7 +32,7 @@ class IssueService
      * @param  Repository  $repo
      * @return array<Issue>
      */
-    private function getIssuesForRepo(Repository $repo): array
+    public function getIssuesForRepo(Repository $repo): array
     {
         $fetchedIssues = Cache::remember(
             $repo->owner.'/'.$repo->name,

--- a/database/migrations/2022_08_10_235101_create_job_batches_table.php
+++ b/database/migrations/2022_08_10_235101_create_job_batches_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('job_batches', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->string('name');
+            $table->integer('total_jobs');
+            $table->integer('pending_jobs');
+            $table->integer('failed_jobs');
+            $table->text('failed_job_ids');
+            $table->mediumText('options')->nullable();
+            $table->integer('cancelled_at')->nullable();
+            $table->integer('created_at');
+            $table->integer('finished_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('job_batches');
+    }
+};


### PR DESCRIPTION
There are now over 688 repos being crawled to build the issues list. When this command runs, it loops through each repo and fetches the issues.

At the moment this process takes over 3 minutes running on a single process. So I've updated this to run on batch to run quicker (the server has 5 queue workers running for this queue).