### PR TITLE
Improved preloading to prevent downtime

### DIFF
--- a/app/Jobs/PreloadIssuesForRepos.php
+++ b/app/Jobs/PreloadIssuesForRepos.php
@@ -31,7 +31,7 @@ class PreloadIssuesForRepos implements ShouldQueue
     public function handle(IssueService $issueService): void
     {
         foreach ($this->repos as $repo) {
-            $issueService->getIssuesForRepo($repo);
+            $issueService->getIssuesForRepo(repo: $repo, forceRefresh: true);
         }
     }
 }

--- a/app/Services/IssueService.php
+++ b/app/Services/IssueService.php
@@ -29,13 +29,20 @@ class IssueService
     }
 
     /**
-     * @param  Repository  $repo
+     * @param Repository $repo
+     * @param bool $forceRefresh
      * @return array<Issue>
      */
-    public function getIssuesForRepo(Repository $repo): array
+    public function getIssuesForRepo(Repository $repo, bool $forceRefresh = false): array
     {
+        $cacheKey = $repo->owner.'/'.$repo->name;
+
+        if ($forceRefresh) {
+            Cache::forget($cacheKey);
+        }
+
         $fetchedIssues = Cache::remember(
-            $repo->owner.'/'.$repo->name,
+            $cacheKey,
             now()->addMinutes(120),
             fn (): array => $this->getIssuesFromGitHubApi($repo),
         );


### PR DESCRIPTION
After my changes yesterday, I've realised that the site was experiencing some downtime (reported by Oh Dear). There's a brief moment of time when the site is refreshing the issues after the cache has expired.

This means that during a web request, the page starts the process to load the repos but this takes a long time!

So I've now updated the caching so that every hour, we "forget" the repo in the cache to force it to be cached for another 2 hours (although it will be refresh again in an hours time). This _should_ prevent the downtime because the issues should always be preloaded in the background and can be resolved from the cache in a web request.