### PR TITLE
Converted 'documentation' link to a button

### DIFF
--- a/public/images/docs-icon.svg
+++ b/public/images/docs-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="#ffffff">
+    <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd" />
+</svg>

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -5,20 +5,11 @@
     </a>
 
     <div class="flex space-x-3 items-center">
-        <a href="https://docs.findapr.io"
-           target="_blank"
-           rel="noreferrer noopener"
-           class="underline font-medium mr-3 text-gray-600 hover:text-green-600 transition ease-out dark:text-gray-100 dark:hover:text-green-600"
-        >
-            Documentation
+        <a href="https://docs.findapr.io" target="_blank"
+           class="flex justify-center items-center h-10 px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-gray-800 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 dark:hover:bg-gray-900 transition ease-out">
+            <img src="{{ asset('images/docs-icon.svg') }}" class="inline w-5 md:pr-2 md:w-6 text-white" alt="View documentation" />
+            <span class="hidden md:inline">Documentation</span>
         </a>
-
-        <button type="button"
-                @click="toggleDarkMode(! isDark)"
-                x-text="darkModeIcon()"
-                class="flex justify-center items-center h-10 px-4 py-1.5 border border-transparent font-medium rounded-md shadow-sm text-white bg-gray-800 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 dark:hover:bg-gray-900 transition ease-out"
-        >
-        </button>
 
         <a href="https://github.com/ash-jc-allen/find-a-pr" target="_blank"
            class="flex justify-center items-center h-10 px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-gray-800 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 dark:hover:bg-gray-900 transition ease-out">
@@ -31,6 +22,15 @@
             <img src="{{ asset('images/twitter-logo.svg') }}" class="inline w-5 md:pr-2 md:w-6" alt="Follow on Twitter" />
             <span class="hidden md:inline"><span class="hidden lg:inline">Follow on </span>Twitter</span>
         </a>
+
+        <div class="mx-6 border-gray-300 border-r h-6 mx-aut dark:border-slate-500"></div>
+
+        <button type="button"
+                @click="toggleDarkMode(! isDark)"
+                x-text="darkModeIcon()"
+                class="flex justify-center items-center h-10 px-4 py-1.5 border border-transparent font-medium rounded-md shadow-sm text-white bg-gray-800 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 dark:hover:bg-gray-900 transition ease-out"
+        >
+        </button>
     </div>
 
 </div>


### PR DESCRIPTION
Before:
<img width="611" alt="Screenshot 2022-08-13 at 13 25 06" src="https://user-images.githubusercontent.com/39652331/184493940-bf775ff6-9abf-4b23-b926-f7dd6bdc779d.png">

After:
<img width="651" alt="Screenshot 2022-08-13 at 13 25 13" src="https://user-images.githubusercontent.com/39652331/184493947-9f39f60f-56f9-4fe9-8952-b2edc17fd1db.png">
