### PR TITLE
Set LOG_CHANNEL to single in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
-LOG_CHANNEL=stack
+LOG_CHANNEL=single
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 


### PR DESCRIPTION
When an error is thrown, the logger tries to log the error to bugsnag. Most of the developers don't have this set up, so another error is shown. This can cause some confusion.

This PR fixes that by setting the `LOG_CHANNEL` in the `.env.example` to `single`.