### PR TITLE
Hide closed ignored issues

### DIFF
--- a/app/Http/Livewire/ListIssues.php
+++ b/app/Http/Livewire/ListIssues.php
@@ -163,6 +163,10 @@ class ListIssues extends Component
 
     public function updatedIgnoredUrls(array $urls): void
     {
+        $this->ignoredUrls = $urls = collect($urls)
+            ->filter(fn ($url) => $this->originalIssues->contains(fn (Issue $issue) => $url === $issue->url))
+            ->toArray();
+
         if (! $urls) {
             $this->showIgnoredIssues = false;
         }

--- a/app/Http/Livewire/ListIssues.php
+++ b/app/Http/Livewire/ListIssues.php
@@ -163,11 +163,13 @@ class ListIssues extends Component
 
     public function updatedIgnoredUrls(array $urls): void
     {
-        $this->ignoredUrls = $urls = collect($urls)
-            ->filter(fn ($url) => $this->originalIssues->contains(fn (Issue $issue) => $url === $issue->url))
+        $this->ignoredUrls = collect($urls)
+            ->filter(function (string $url): bool {
+                return $this->originalIssues->contains(fn (Issue $issue): bool => $url === $issue->url);
+            })
             ->toArray();
 
-        if (! $urls) {
+        if (! $this->ignoredUrls) {
             $this->showIgnoredIssues = false;
         }
     }


### PR DESCRIPTION
Ignored issues are saved in local storage. The local storage is not aware of closed issues. If you have an ignored issue in your local storage, the ignored issue filter would always be visible, even if you don't have ignored issues that are still open.