### PR TITLE
Fix bug that was preventing access if a repo doesn't exist anymore

### DIFF
--- a/app/Console/Commands/PreloadRepoData.php
+++ b/app/Console/Commands/PreloadRepoData.php
@@ -29,10 +29,8 @@ class PreloadRepoData extends Command
 
         $this->components->info('Dispatching '.count($batches).' jobs in a batch to find repos.');
 
-        logger('start');
         Bus::batch($batches)
             ->then(function (): void {
-                logger('end');
                 Artisan::call('issues:tweet');
             })
             ->dispatch();

--- a/app/Services/IssueService.php
+++ b/app/Services/IssueService.php
@@ -194,6 +194,8 @@ class IssueService
             throw new GitHubRateLimitException('GitHub API rate limit reached!');
         }
 
+        report($fullRepoName.' is a forbidden GitHub repo.');
+
         return [];
     }
 

--- a/app/Services/IssueService.php
+++ b/app/Services/IssueService.php
@@ -10,6 +10,7 @@ use App\DataTransferObjects\Reaction;
 use App\DataTransferObjects\Repository;
 use App\Exceptions\GitHubRateLimitException;
 use Carbon\Carbon;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
@@ -142,12 +143,14 @@ class IssueService
      */
     private function getIssuesFromGitHubApi(Repository $repo): array
     {
+        $fullRepoName = $repo->owner.'/'.$repo->name;
+
         $result = app(GitHub::class)
             ->client()
-            ->get($repo->owner.'/'.$repo->name.'/issues');
+            ->get($fullRepoName.'/issues');
 
-        if (! $result->successful()) {
-            throw new GitHubRateLimitException('GitHub API rate limit reached!');
+        if (!$result->successful()) {
+            return $this->handleUnsuccessfulIssueRequest($result, $fullRepoName);
         }
 
         $fetchedIssues = $result->json();
@@ -156,4 +159,42 @@ class IssueService
             ->map(fn (array $fetchedIssue): Issue => $this->parseIssue($repo, $fetchedIssue))
             ->all();
     }
+
+    /**
+     * @param Response $response
+     * @param string $fullRepoName
+     * @return array
+     * @throws GitHubRateLimitException
+     */
+    private function handleUnsuccessfulIssueRequest(Response $response, string $fullRepoName): array
+    {
+        return match ($response->status()) {
+            404 => $this->handleNotFoundResponse($fullRepoName),
+            403 => $this->handleForbiddenResponse($response, $fullRepoName),
+            default => [],
+        };
+    }
+
+    private function handleNotFoundResponse(string $fullRepoName): array
+    {
+        report($fullRepoName.' is not a valid GitHub repo.');
+
+        return [];
+    }
+
+    /**
+     * @param Response $response
+     * @param string $fullRepoName
+     * @return array
+     * @throws GitHubRateLimitException
+     */
+    private function handleForbiddenResponse(Response $response, string $fullRepoName): array
+    {
+        if ($response->header('X-RateLimit-Remaining') === '0') {
+            throw new GitHubRateLimitException('GitHub API rate limit reached!');
+        }
+
+        return [];
+    }
+
 }


### PR DESCRIPTION
This PR fixes a bug that is preventing access to Find A PR if a repo doesn't exist anymore.

I had originally added a check to see if the API call was unsuccessful. If it was unsuccessful, then I naively made the assumption that the rate limit had been hit and throw an exception! But there was recently a Spatie repo that has been removed (or maybe made private?). This was triggering the "unsuccessful" check and triggering our rate limit exception.

I've _hopefully_ fixed this issue by making the checks more granular and checking the status codes rather (like I probably should have done in the first place haha!) 😄