### PR TITLE
Added command to find archived repos

### DIFF
--- a/app/Console/Commands/EnsureCrawlableRepos.php
+++ b/app/Console/Commands/EnsureCrawlableRepos.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Jobs\EnsureRepoIsCrawlable;
+use App\Services\RepoService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+final class EnsureCrawlableRepos extends Command
+{
+    protected $signature = 'repos:crawlable';
+
+    protected $description = 'Loop through each repo and ensure it is crawlable. Alert if not.';
+
+    /**
+     * @return int
+     * @throws \Throwable
+     */
+    public function handle(): int
+    {
+        $jobsCount = app(RepoService::class)
+            ->reposToCrawl()
+            ->chunk(25)
+            ->each(function (Collection $repos): void {
+                dispatch(new EnsureRepoIsCrawlable($repos));
+            })
+            ->count();
+
+        $this->components->info('Dispatched '.$jobsCount.' jobs to ensure repos are crawlable.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -17,6 +17,7 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         $schedule->command('repos:preload')->hourly();
+        $schedule->command('repos:crawlable')->weekly();
 
         // Ping OhDear to make sure the scheduler and default queue is running.
         $schedule->job(new SendPing(config('services.ohdear.ping_url')))->everyMinute();

--- a/app/Exceptions/RepoNotCrawlableException.php
+++ b/app/Exceptions/RepoNotCrawlableException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+final class RepoNotCrawlableException extends \Exception
+{
+}

--- a/app/Jobs/EnsureRepoIsCrawlable.php
+++ b/app/Jobs/EnsureRepoIsCrawlable.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\DataTransferObjects\Repository;
+use App\Services\RepoService;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+final class EnsureRepoIsCrawlable implements ShouldQueue
+{
+    use Batchable;
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * @param  Collection<Repository>  $repos
+     */
+    public function __construct(private readonly Collection $repos)
+    {
+        //
+    }
+
+    public function handle(RepoService $repoService): void
+    {
+        foreach ($this->repos as $repo) {
+            $repoService->repoCanBeCrawled($repo);
+        }
+    }
+}

--- a/app/Jobs/EnsureRepoIsCrawlable.php
+++ b/app/Jobs/EnsureRepoIsCrawlable.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use App\DataTransferObjects\Repository;
+use App\Exceptions\RepoNotCrawlableException;
 use App\Services\RepoService;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
@@ -33,7 +34,11 @@ final class EnsureRepoIsCrawlable implements ShouldQueue
     public function handle(RepoService $repoService): void
     {
         foreach ($this->repos as $repo) {
-            $repoService->repoCanBeCrawled($repo);
+            try {
+                $repoService->ensureRepoCanBeCrawled($repo);
+            } catch (RepoNotCrawlableException $e) {
+                report($e);
+            }
         }
     }
 }

--- a/app/Services/RepoService.php
+++ b/app/Services/RepoService.php
@@ -64,21 +64,21 @@ final class RepoService
             ->get($fullRepoName);
 
         if (! $result->successful()) {
-            return $this->handleUnsuccessfulIssueRequest($result, $fullRepoName);
+            $this->handleUnsuccessfulIssueRequest($result, $fullRepoName);
         }
 
         return $result->json();
     }
 
     /**
-     * @param  Response  $response
-     * @param  string  $fullRepoName
-     * @return array
+     * @param Response $response
+     * @param string $fullRepoName
+     * @return void
      *
      * @throws GitHubRateLimitException
      * @throws RepoNotCrawlableException
      */
-    private function handleUnsuccessfulIssueRequest(Response $response, string $fullRepoName): array
+    private function handleUnsuccessfulIssueRequest(Response $response, string $fullRepoName): void
     {
         match ($response->status()) {
             404 => $this->handleNotFoundResponse($fullRepoName),

--- a/app/Services/RepoService.php
+++ b/app/Services/RepoService.php
@@ -20,11 +20,10 @@ class RepoService
                     $repoNames,
                     static fn (string $repoName): Repository => new Repository($owner, $repoName)
                 );
-            })
-            ->filter(fn (Repository $repository): bool => $this->repoCanBeCrawled($repository));
+            });
     }
 
-    private function repoCanBeCrawled(Repository $repository): bool
+    public function repoCanBeCrawled(Repository $repository): bool
     {
         $repositoryData = $this->cacheRepoData($repository);
 


### PR DESCRIPTION
This PR removes the "archived" check from the preload command. It seems to be taking too long to filter through all of the repositories to check whether they're archived.

So I've moved the "archived" into its own command that can be run once a week. If an archived (or non-existent) repo is found, I'll be alerted through error monitoring so I can remove it from the `config/repos.php` file 🙂