### PR TITLE
Making the labels in the sidebar usable as search filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the official repository for [Find A PR](https://findapr.io/). Find A PR 
 
 The following tools are required in order to start the installation and run the project locally.
 
-- PHP 8.1
+- PHP 8.2
 - [Composer](https://getcomposer.org/download/)
 
 ## Installation

--- a/app/Livewire/ListIssues.php
+++ b/app/Livewire/ListIssues.php
@@ -157,9 +157,10 @@ final class ListIssues extends Component
         };
     }
 
-    public function toggleSearchLabel(string $label)
+    public function toggleSearchLabel(string $label): void
     {
-        $key = array_search($label, $this->searchLabels);
+        $key = array_search($label, $this->searchLabels, strict: true);
+
         if ($key !== false) {
             unset($this->searchLabels[$key]);
         } else {

--- a/app/Livewire/ListIssues.php
+++ b/app/Livewire/ListIssues.php
@@ -138,12 +138,10 @@ final class ListIssues extends Component
 
     private function applySearchLabel(): \Closure
     {
-        return static function (Collection $issues, array $searchLabels) : Collection {
+        return static function (Collection $issues, array $searchLabels): Collection {
             return $issues->filter(function (Issue $issue) use ($searchLabels): bool {
-                foreach ($searchLabels as $searchLabel)
-                {
-                    if (collect($issue->labels)->contains('name', $searchLabel))
-                    {
+                foreach ($searchLabels as $searchLabel) {
+                    if (collect($issue->labels)->contains('name', $searchLabel)) {
                         return true;
                     }
                 }

--- a/app/Livewire/ListIssues.php
+++ b/app/Livewire/ListIssues.php
@@ -145,6 +145,7 @@ final class ListIssues extends Component
                         return true;
                     }
                 }
+
                 return false;
             });
         };

--- a/resources/views/components/side-bar.blade.php
+++ b/resources/views/components/side-bar.blade.php
@@ -64,7 +64,14 @@
 
         @foreach($labels as $name => $count)
             <div>
-                <button class="inline-block items-center px-3 py-1 my-0.5 rounded text-xs space-x-1 font-bold @if (in_array($name, $this->searchLabels)) bg-green-400 dark:bg-green-600 @else bg-gray-400 dark:bg-gray-600 @endif text-white hover:bg-green-500 dark:hover:bg-green-700 transition ease-out" wire:click="toggleSearchLabel('{{ $name }}')">
+                <button
+                    @class([
+                        'inline-block items-center px-3 py-1 my-0.5 rounded text-xs space-x-1 font-bold text-white hover:bg-green-500 dark:hover:bg-green-700 transition ease-out',
+                        'bg-green-400 dark:bg-green-600' => in_array($name, $this->searchLabels, strict: true),
+                        'bg-gray-400 dark:bg-gray-600' => ! in_array($name, $this->searchLabels, strict: true),
+                    ])
+                    wire:click="toggleSearchLabel('{{ $name }}')"
+                >
                     <span>{{ $name }}</span>
                     <span>({{$count}})</span>
                 </button>

--- a/resources/views/components/side-bar.blade.php
+++ b/resources/views/components/side-bar.blade.php
@@ -64,7 +64,7 @@
 
         @foreach($labels as $name => $count)
             <div>
-                <button class="inline-block items-center px-3 py-1 my-0.5 rounded text-xs space-x-1 font-bold @if (in_array($label, $this->searchLabels)) bg-green-400 dark:bg-green-600 @else bg-gray-400 dark:bg-gray-600 @endif text-white hover:bg-green-500 dark:hover:bg-green-700 transition ease-out" wire:click="toggleSearchLabel('{{ $name }}')">
+                <button class="inline-block items-center px-3 py-1 my-0.5 rounded text-xs space-x-1 font-bold @if (in_array($name, $this->searchLabels)) bg-green-400 dark:bg-green-600 @else bg-gray-400 dark:bg-gray-600 @endif text-white hover:bg-green-500 dark:hover:bg-green-700 transition ease-out" wire:click="toggleSearchLabel('{{ $name }}')">
                     <span>{{ $name }}</span>
                     <span>({{$count}})</span>
                 </button>

--- a/resources/views/components/side-bar.blade.php
+++ b/resources/views/components/side-bar.blade.php
@@ -64,9 +64,9 @@
 
         @foreach($labels as $label)
             <div>
-                <p class="inline-block items-center px-3 py-1 my-0.5 rounded text-xs font-bold border bg-gray-400 dark:bg-gray-600 text-white">
+                <button class="inline-block items-center px-3 py-1 my-0.5 rounded text-xs font-bold @if (in_array($label, $this->searchLabels)) bg-green-400 dark:bg-green-600 @else bg-gray-400 dark:bg-gray-600 @endif text-white hover:bg-green-500 dark:hover:bg-green-700 transition ease-out" wire:click="toggleSearchLabel('{{ $label }}')">
                     {{ $label }}
-                </p>
+                </button>
             </div>
         @endforeach
     </div>


### PR DESCRIPTION
I was really surprised the labels in the sidebar did nothing, so I made them usable as search filters that can be toggled. If an issue has any of the enabled labels it is shown. There's a couple of different ways, you could do this, but I think this is the most straightforward. 

Also a slight update of the readme. 