### PR TITLE
Display the related count next to the issue's label

### DIFF
--- a/app/Livewire/ListIssues.php
+++ b/app/Livewire/ListIssues.php
@@ -111,7 +111,7 @@ final class ListIssues extends Component
                         $this->setLabelsCount($issue);
                     }
                     return true;
-                };
+                }
 
                 return false;
             })
@@ -147,7 +147,6 @@ final class ListIssues extends Component
 
                 return $matched;
             });
-
         };
     }
 

--- a/app/Livewire/ListIssues.php
+++ b/app/Livewire/ListIssues.php
@@ -110,9 +110,9 @@ final class ListIssues extends Component
                     if (! $this->searchTerm) {
                         $this->setLabelsCount($issue);
                     }
+
                     return true;
                 }
-
                 return false;
             })
             ->when($this->searchTerm, $this->applySearch())
@@ -144,6 +144,7 @@ final class ListIssues extends Component
                 if ($matched) {
                     $this->setLabelsCount($issue);
                 }
+
                 return $matched;
             });
         };

--- a/app/Livewire/ListIssues.php
+++ b/app/Livewire/ListIssues.php
@@ -102,7 +102,7 @@ final class ListIssues extends Component
 
     public function render(): View
     {
-        $this->setLabels();
+        $this->initialiseLabels();
 
         $issues = $this->originalIssues
             ->filter(function (Issue $issue): bool {
@@ -188,7 +188,12 @@ final class ListIssues extends Component
         }
     }
 
-    private function setLabels(): void
+    /**
+     * Initialise each of the labels with counts of 0.
+     *
+     * @return void
+     */
+    private function initialiseLabels(): void
     {
         foreach (config('repos.labels') as $label) {
             $this->labels[$label] = 0;
@@ -197,11 +202,20 @@ final class ListIssues extends Component
 
     private function setLabelsCount(Issue $issue): void
     {
-        collect($issue->labels)
-            ->each(function (Label $label) {
-                if (isset($this->labels[$label->name])) {
-                    $this->labels[$label->name] += 1;
-                }
-            });
+        foreach ($issue->labels as $label) {
+            if (!$this->isValidLabel($label)) {
+                continue;
+            }
+
+            $this->labels[$label->name]++;
+        }
+    }
+
+    /**
+     * Assert whether the label is one that we're tracking in Find A PR.
+     */
+    private function isValidLabel(Label $label): bool
+    {
+        return array_key_exists($label->name, $this->labels);
     }
 }

--- a/app/Livewire/ListIssues.php
+++ b/app/Livewire/ListIssues.php
@@ -113,6 +113,7 @@ final class ListIssues extends Component
 
                     return true;
                 }
+
                 return false;
             })
             ->when($this->searchTerm, $this->applySearch())

--- a/app/Livewire/ListIssues.php
+++ b/app/Livewire/ListIssues.php
@@ -144,7 +144,6 @@ final class ListIssues extends Component
                 if ($matched) {
                     $this->setLabelsCount($issue);
                 }
-
                 return $matched;
             });
         };

--- a/resources/views/components/side-bar.blade.php
+++ b/resources/views/components/side-bar.blade.php
@@ -63,12 +63,12 @@
         </div>
 
         @foreach($labels as $name => $count)
-                <div class="flex justify-between">
-                    <p class="inline-block items-center px-3 py-1 my-0.5 space-x-1 rounded text-xs font-bold border bg-gray-400 dark:bg-gray-600 text-white">
-                        <span>{{ $name }}</span>
-                        <span>({{$count}})</span>
-                    </p>
-                </div>
+            <div>
+                <p class="inline-block items-center px-3 py-1 my-0.5 space-x-1 rounded text-xs font-bold border bg-gray-400 dark:bg-gray-600 text-white">
+                    <span>{{ $name }}</span>
+                    <span>({{$count}})</span>
+                </p>
+            </div>
         @endforeach
     </div>
 </div>

--- a/resources/views/components/side-bar.blade.php
+++ b/resources/views/components/side-bar.blade.php
@@ -62,12 +62,13 @@
             <p class="text-gray-400 text-sm">({{ count($labels) }})</p>
         </div>
 
-        @foreach($labels as $label)
-            <div>
-                <p class="inline-block items-center px-3 py-1 my-0.5 rounded text-xs font-bold border bg-gray-400 dark:bg-gray-600 text-white">
-                    {{ $label }}
-                </p>
-            </div>
+        @foreach($labels as $name => $count)
+                <div class="flex justify-between">
+                    <p class="inline-block items-center px-3 py-1 my-0.5 space-x-1 rounded text-xs font-bold border bg-gray-400 dark:bg-gray-600 text-white">
+                        <span>{{ $name }}</span>
+                        <span>({{$count}})</span>
+                    </p>
+                </div>
         @endforeach
     </div>
 </div>


### PR DESCRIPTION
It's useful if labels are clickable and numbers are displayed. Related to #198 

![Screenshot 2024-08-11 105626](https://github.com/user-attachments/assets/ace0bb89-e872-4cca-8047-d814fe327874)
