### PR TITLE
Change the status code from 503 to 429

### DIFF
--- a/app/Livewire/ListIssues.php
+++ b/app/Livewire/ListIssues.php
@@ -96,7 +96,7 @@ final class ListIssues extends Component
         try {
             $this->originalIssues = app(IssueService::class)->getAll()->shuffle();
         } catch (GitHubRateLimitException $e) {
-            abort(503, $e->getMessage());
+            abort(429, $e->getMessage());
         }
 
         $this->shouldDisplayFirstTimeNotice = ! Cookie::get('firstTimeNoticeClosed');


### PR DESCRIPTION
In app/Livewire/ListIssues.php around line 98 where we are catching GitHubRateLimitException, we are returning a 503 status code. 

503 indicates the server is temporarily unable to handle the request. I do not think that is precise enough for what is happening and status 429 would be more appropriate.

HTTP status code 429 is specifically designed for rate limiting scenarios. It indicates the user has sent too many requests in a given amount of time ("rate limiting"), which is what the GitHubRateLimitException is meant to catch. 